### PR TITLE
Add react/require-default-props rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ module.exports = {
     'react/prefer-es6-class': 'error',
     'react/prefer-stateless-function': 'error',
     'react/react-in-jsx-scope': 'error',
+    'react/require-default-props': 'warn',
     'react/self-closing-comp': 'error',
     'react/sort-prop-types': 'error',
     'react-hooks/rules-of-hooks': 'error',


### PR DESCRIPTION
## Add `react/require-default-props` rule

Adds a warning every time a non required `PropType` is missing the corresponding `defaultProps`.

## Reason

This rule was present on the previous `.eslintrc` configuration so I'm adding it back.

## Questions

What do you guys think, should it be `warn` or `error`?