### PR TITLE
Add prettier support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,19 +27,22 @@
     "version": "npm run changelog --future-release=$npm_package_version && git add -A CHANGELOG.md"
   },
   "dependencies": {
-    "babel-eslint": "^10.0.1",
-    "eslint-config-uphold": "^0.2.0",
-    "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-react": "^7.12.4",
-    "eslint-plugin-react-hooks": "^1.6.0",
-    "eslint-plugin-sort-class-members": "^1.4.0",
-    "jest": "^24.7.1"
+    "babel-eslint": "10.0.1",
+    "eslint-config-prettier": "6.0.0",
+    "eslint-config-uphold": "0.2.0",
+    "eslint-plugin-import": "2.16.0",
+    "eslint-plugin-prettier": "3.1.0",
+    "eslint-plugin-react": "7.12.4",
+    "eslint-plugin-react-hooks": "1.6.0",
+    "eslint-plugin-sort-class-members": "1.4.0",
+    "jest": "24.7.1",
+    "prettier": "1.18.2"
   },
   "devDependencies": {
-    "@uphold/github-changelog-generator": "^0.8.1",
-    "eslint": "^5.16.0",
-    "husky": "^1.3.1",
-    "react": "^16.8.6"
+    "@uphold/github-changelog-generator": "0.8.1",
+    "eslint": "5.16.0",
+    "husky": "1.3.1",
+    "react": "16.8.6"
   },
   "husky": {
     "hooks": {

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,9 @@ module.exports = {
   },
   extends: [
     'plugin:react/recommended',
-    'uphold'
+    'uphold',
+    'plugin:prettier/recommended',
+    'prettier/react'
   ],
   parser: 'babel-eslint',
   parserOptions: {
@@ -20,44 +22,33 @@ module.exports = {
       jsx: true
     }
   },
-  plugins: [
-    'import',
-    'react',
-    'react-hooks',
-    'sort-class-members'
-  ],
+  plugins: ['import', 'react', 'react-hooks', 'sort-class-members'],
   root: true,
   rules: {
     'import/default': 'error',
     'import/named': 'error',
     'import/no-unresolved': 'error',
-    'jsx-quotes': ['error', 'prefer-double'],
-    'no-extra-parens': ['error', 'all', {
-      ignoreJSX: 'all'
-    }],
+    'operator-linebreak': 0,
+    'prettier/prettier': [
+      'error',
+      {
+        singleQuote: true
+      }
+    ],
     'react/display-name': 'error',
     'react/jsx-boolean-value': 'error',
-    'react/jsx-closing-bracket-location': 'error',
-    'react/jsx-curly-brace-presence': ['error', {
-      props: 'never'
-    }],
-    'react/jsx-curly-spacing': 'error',
-    'react/jsx-indent': ['error', 2],
-    'react/jsx-indent-props': ['error', 2],
+    'react/jsx-curly-brace-presence': [
+      'error',
+      {
+        props: 'never'
+      }
+    ],
     'react/jsx-key': 'error',
-    'react/jsx-max-props-per-line': ['error', { maximum: 3 }],
     'react/jsx-no-duplicate-props': 'error',
     'react/jsx-no-undef': 'error',
     'react/jsx-sort-props': 'error',
-    'react/jsx-tag-spacing': ['error', {
-      afterOpening: 'never',
-      beforeClosing: 'never',
-      beforeSelfClosing: 'always',
-      closingSlash: 'never'
-    }],
     'react/jsx-uses-react': 'error',
     'react/jsx-uses-vars': 'error',
-    'react/jsx-wrap-multilines': 'error',
     'react/no-danger': 'error',
     'react/no-direct-mutation-state': 'error',
     'react/no-string-refs': 'error',
@@ -69,23 +60,32 @@ module.exports = {
     'react/self-closing-comp': 'error',
     'react/sort-prop-types': 'error',
     'react-hooks/rules-of-hooks': 'error',
-    /* eslint-disable sort-keys */
-    'sort-class-members/sort-class-members': ['error', {
-      order: [
-        '[static-properties-alpha]',
-        '[static-methods-alpha]',
-        '[properties-alpha]',
-        '[constructor]',
-        '[methods-alpha]'
-      ],
-      groups: {
-        'static-properties-alpha': [{ type: 'property', static: true, sort: 'alphabetical' }],
-        'static-methods-alpha': [{ type: 'method', static: true, sort: 'alphabetical' }],
-        'properties-alpha': [{ type: 'property', propertyType: 'Literal', sort: 'alphabetical' }],
-        'methods-alpha': [{ type: 'method', sort: 'alphabetical' }]
+    'sort-class-members/sort-class-members': [
+      'error',
+      {
+        /* eslint-disable sort-keys */
+        order: [
+          '[static-properties-alpha]',
+          '[static-methods-alpha]',
+          '[properties-alpha]',
+          '[constructor]',
+          '[methods-alpha]'
+        ],
+        groups: {
+          'static-properties-alpha': [
+            { type: 'property', static: true, sort: 'alphabetical' }
+          ],
+          'static-methods-alpha': [
+            { type: 'method', static: true, sort: 'alphabetical' }
+          ],
+          'properties-alpha': [
+            { type: 'property', propertyType: 'Literal', sort: 'alphabetical' }
+          ],
+          'methods-alpha': [{ type: 'method', sort: 'alphabetical' }]
+        }
+        /* eslint-enable sort-keys */
       }
-    }]
-    /* eslint-enable sort-keys */
+    ]
   },
   settings: {
     react: {

--- a/test/__snapshots__/rules.test.js.snap
+++ b/test/__snapshots__/rules.test.js.snap
@@ -3,11 +3,6 @@
 exports[`eslint-config-uphold-react should generate violations for incorrect code 1`] = `
 Array [
   "react-hooks/rules-of-hooks",
-  "react/jsx-tag-spacing",
-  "react/jsx-tag-spacing",
-  "react/jsx-tag-spacing",
-  "react/jsx-tag-spacing",
-  "react/jsx-tag-spacing",
   "react/prefer-stateless-function",
 ]
 `;

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -1,4 +1,7 @@
 // `jasmine`, `jest` and `mocha` envs.
+/* eslint-disable prettier/prettier */
+
+const React = null;
 
 // Avoid extra `no-unused-vars` violations.
 function noop() {
@@ -17,7 +20,7 @@ const RulesOfHooks = () => {
 noop(RulesOfHooks);
 
 // `react/jsx-tag-spacing`.
-const React = null;
+
 
 const TagSpacing = () => (
   <div />

--- a/test/fixtures/incorrect.js
+++ b/test/fixtures/incorrect.js
@@ -1,3 +1,7 @@
+/* eslint-disable prettier/prettier */
+
+const React = null;
+
 // Avoid extra `no-unused-vars` violations.
 function noop() {
   // Do nothing
@@ -15,35 +19,6 @@ const RulesOfHooks = () => {
 };
 
 noop(RulesOfHooks);
-
-// `react/jsx-tag-spacing`.
-const React = null;
-
-const TagSpacingAfterOpening = () => (
-  < div />
-);
-
-noop(TagSpacingAfterOpening);
-
-const TagSpacingBeforeClosing = () => (
-  <div>
-    {'foo'}
-  </div >
-);
-
-noop(TagSpacingBeforeClosing);
-
-const TagSpacingBeforeSelfClosing = () => (
-  <div/>
-);
-
-noop(TagSpacingBeforeSelfClosing);
-
-const TagSpacingClosingSlash = () => (
-  <div/ >
-);
-
-noop(TagSpacingClosingSlash);
 
 // `react/prefer-stateless-function`.
 class PreferStatelessFunction extends React.Component {

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -12,7 +12,9 @@ const path = require('path');
  */
 
 describe('eslint-config-uphold-react', () => {
-  const linter = new Linter({ configFile: path.join(__dirname, '..', 'src', 'index.js') });
+  const linter = new Linter({
+    configFile: path.join(__dirname, '..', 'src', 'index.js')
+  });
 
   test('should not generate any violation for correct code', () => {
     const source = path.join(__dirname, 'fixtures', 'correct.js');
@@ -22,7 +24,9 @@ describe('eslint-config-uphold-react', () => {
 
   it('should generate violations for incorrect code', () => {
     const source = path.join(__dirname, 'fixtures', 'incorrect.js');
-    const rules = linter.executeOnFiles([source]).results[0].messages.map(violation => violation.ruleId);
+    const rules = linter
+      .executeOnFiles([source])
+      .results[0].messages.map(violation => violation.ruleId);
 
     expect(rules).toMatchSnapshot();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,7 +346,7 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
   integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
 
-"@uphold/github-changelog-generator@^0.8.1":
+"@uphold/github-changelog-generator@0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@uphold/github-changelog-generator/-/github-changelog-generator-0.8.1.tgz#1248bef4d85b212a3e31538f1737bc2f45610ac5"
   integrity sha512-dluWg7rMIJoDipmCHRK8eO2FCZGPDcFnVusQ179jEPjqgSGkNwEWFBk0JjqFtZ5NEoP7vFSdmVW+EeVNPGdqlQ==
@@ -581,7 +581,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-eslint@^10.0.1:
+babel-eslint@10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
   integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
@@ -1248,7 +1248,14 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-uphold@^0.2.0:
+eslint-config-prettier@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz#f429a53bde9fc7660e6353910fd996d6284d3c25"
+  integrity sha512-vDrcCFE3+2ixNT5H83g28bO/uYAwibJxerXPj+E7op4qzBCsAV36QfvdAyVOoNxKAH2Os/e01T/2x++V0LPukA==
+  dependencies:
+    get-stdin "^6.0.0"
+
+eslint-config-uphold@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-uphold/-/eslint-config-uphold-0.2.0.tgz#3fd7a26ed33cc167e5ed1a41196bc8d6dde957f1"
   integrity sha512-MbA35MCKO/Q9rDx/rq7MIpXSy+aptQGpXYzAKdTxBfDVSuHJwftB0w6uwMinKSa9YJwrXSMMnexY67qPzSLNCA==
@@ -1275,7 +1282,7 @@ eslint-module-utils@^2.3.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
-eslint-plugin-import@^2.16.0:
+eslint-plugin-import@2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz#97ac3e75d0791c4fac0e15ef388510217be7f66f"
   integrity sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==
@@ -1298,12 +1305,19 @@ eslint-plugin-mocha@^5.1.0:
   dependencies:
     ramda "^0.26.1"
 
-eslint-plugin-react-hooks@^1.6.0:
+eslint-plugin-prettier@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
+  integrity sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-react-hooks@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
   integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
 
-eslint-plugin-react@^7.12.4:
+eslint-plugin-react@7.12.4:
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"
   integrity sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==
@@ -1316,7 +1330,7 @@ eslint-plugin-react@^7.12.4:
     prop-types "^15.6.2"
     resolve "^1.9.0"
 
-eslint-plugin-sort-class-members@^1.0.1, eslint-plugin-sort-class-members@^1.4.0:
+eslint-plugin-sort-class-members@1.4.0, eslint-plugin-sort-class-members@^1.0.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.4.0.tgz#71295d127752131e798ed1e5e76970f2c2c3ae48"
   integrity sha512-FQG6d4Cy2vYmG9gr6J138E91WaltqwOk/b/7GCssPqnUmizrcgOeN91bV5eOTuoS4RSH1Jdn4ukWEtyWLwV8ig==
@@ -1359,7 +1373,7 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@^5.16.0:
+eslint@5.16.0:
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
   integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
@@ -1549,6 +1563,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1879,7 +1898,7 @@ https-proxy-agent@^2.2.0:
     agent-base "^4.1.0"
     debug "^3.1.0"
 
-husky@^1.3.1:
+husky@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/husky/-/husky-1.3.1.tgz#26823e399300388ca2afff11cfa8a86b0033fae0"
   integrity sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==
@@ -2594,7 +2613,7 @@ jest-worker@^24.6.0:
     merge-stream "^1.0.1"
     supports-color "^6.1.0"
 
-jest@^24.7.1:
+jest@24.7.1:
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.7.1.tgz#0d94331cf510c75893ee32f87d7321d5bf8f2501"
   integrity sha512-AbvRar5r++izmqo5gdbAjTeA6uNRGoNRuj5vHB0OnDXo2DXWZJVuaObiGgtlvhKb+cWy2oYbQSfxv7Q7GjnAtA==
@@ -3457,6 +3476,18 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 pretty-format@^24.7.0:
   version "24.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.7.0.tgz#d23106bc2edcd776079c2daa5da02bcb12ed0c10"
@@ -3542,7 +3573,7 @@ react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react@^16.8.6:
+react@16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==


### PR DESCRIPTION
## Description

Add [Prettier](https://prettier.io/) support to the Eslint configuration. Prettier is a **very** opinionated code formatter used by all the big names on our field.

The opinionated nature has is drawbacks since it will not support any variation from their defaults or avant-garde code styling ideas. On the plus side it ensures healthy defaults, a strong standardisation and on big projects like this, it's needed.

## Motivation

The idea behind this new feature to our linter is to improve our code, by making it more consistent. There is also a nice side effect of reducing the back and forth discussions about code styling on PRs.

## Usage

The Prettier is configured like any other Eslint plugin (even though it isn't a normal Eslint plugin 😉) and will work automatically. Every time we run

```sh
$ yarn lint
```

it will automatically run Prettier and raise errors if some code is malformed.

This means it will also fix everything when used in conjunction with the `fix` flag
```sh
$ yarn lint --fix
```

## Next steps

The idea of this PR is to serve has a place to discuss the [current](https://github.com/uphold/eslint-config-uphold-react/blob/enhancement/add-prettier/src/index.js#L32) Prettier configuration and side effects.

Below there are a couple of examples of changes Prettier has done to both `mobile` and `manager` projects.


### Examples

* [Ternary](https://github.com/uphold/wallet-app/compare/enhancement/integrate-prettier#diff-5c450c2018ced96c30ade374b02d59cdR14)
* [Multiline object](https://github.com/uphold/wallet-app/compare/enhancement/integrate-prettier#diff-5ce183772ce3757602bf7f706b19dfadL13)
* [Multiline JSX](https://github.com/uphold/wallet-app/compare/enhancement/integrate-prettier#diff-560ce35057c7002778896373882dd00aL41)
* [Multiline JSX v2](https://github.com/uphold/wallet-app/compare/enhancement/integrate-prettier#diff-c11c0429e3e23316154378d5921b03b5L132)
* [Max line breaking](https://github.com/uphold/wallet-app/compare/enhancement/integrate-prettier#diff-c11c0429e3e23316154378d5921b03b5L123)
* [Chaining](https://github.com/uphold/wallet-app/compare/enhancement/integrate-prettier#diff-4c281c9d81ad392823fe71413eb662c8L6)

Branch with the full `mobile` and `manager` projects after Prettier has done is magic is [here](https://github.com/uphold/wallet-app/tree/enhancement/integrate-prettier).

## Questions

*  Should we change anything on our current Prettier configuration? Full list of options [here](https://prettier.io/docs/en/options.html).
* Should we use Prettier at all or continue to improve our Eslint configuration until it reaches the same level of quality?