### PR TITLE
Add new-cap rule `BigNumber` exception

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ module.exports = {
     'import/named': 'error',
     'import/no-unresolved': 'error',
     'jsx-quotes': ['error', 'prefer-double'],
+    'new-cap': ['error', { capIsNewExceptions: ['BigNumber'] }],
     'react/display-name': 'error',
     'react/jsx-boolean-value': 'error',
     'react/jsx-curly-brace-presence': [

--- a/test/fixtures/correct.js
+++ b/test/fixtures/correct.js
@@ -33,3 +33,8 @@ noop(PreferStatelessFunction);
 const PrettierReact = () => <div />;
 
 noop(PrettierReact);
+
+// new-cap exception for `Bignumber`
+const BigNumber = () => {};
+
+noop(BigNumber());


### PR DESCRIPTION
### Description

Add exception to `new-cap` rule for `BigNumber`.

This will allow doing:

```js
return BigNumber(amount).gt(0);
```

without disabling the rule.