### PR TITLE
Add 'react/boolean-prop-naming' rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,12 @@ module.exports = {
     'import/no-unresolved': 'error',
     'jsx-quotes': ['error', 'prefer-double'],
     'new-cap': ['error', { capIsNewExceptions: ['BigNumber'] }],
+    'react/boolean-prop-naming': [
+      'error',
+      {
+        rule: '^(has|is|should)[A-Z]([A-Za-z0-9]?)+'
+      }
+    ],
     'react/display-name': 'error',
     'react/jsx-boolean-value': 'error',
     'react/jsx-curly-brace-presence': [


### PR DESCRIPTION
### Description

Add [`react/boolean-prop-naming`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/boolean-prop-naming.md) rule.

This rule enforces a consistent naming pattern for props which expect a boolean value. The default configuration is to enforce a `is` or `has` prefix for all `PropTypes.bool`.