### PR TITLE
Add 'react-hooks/exhaustive-deps' rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ module.exports = {
     'react/require-default-props': 'warn',
     'react/self-closing-comp': 'error',
     'react/sort-prop-types': 'error',
+    'react-hooks/exhaustive-deps': 'error',
     'react-hooks/rules-of-hooks': 'error',
     /* eslint-disable sort-keys */
     'sort-class-members/sort-class-members': [


### PR DESCRIPTION
### Description

Add [`react-hooks/exhaustive-deps`](https://www.npmjs.com/package/eslint-plugin-react-hooks) rule.

This rule enforces an exhaustive dependency declaration for `useCallback`, `useEffect` and `useMemo`. There is also an option to add custom hook to the validation.