### PR TITLE
Add 'react/no-unused-prop-types' rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ module.exports = {
     'react/no-direct-mutation-state': 'error',
     'react/no-string-refs': 'error',
     'react/no-unknown-property': 'error',
+    'react/no-unused-prop-types': 'error',
     'react/prefer-es6-class': 'error',
     'react/prefer-stateless-function': 'error',
     'react/react-in-jsx-scope': 'error',


### PR DESCRIPTION
### Description

Add [`react/no-unused-prop-types`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) rule.

This rule warns if a prop with a defined type isn't being used.