### PR TITLE
Add 'react/jsx-newline' rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,12 @@ module.exports = {
       }
     ],
     'react/jsx-key': 'error',
+    'react/jsx-newline': [
+      'error',
+      {
+        prevent: false
+      }
+    ],
     'react/jsx-no-duplicate-props': 'error',
     'react/jsx-no-undef': 'error',
     'react/jsx-sort-props': 'error',


### PR DESCRIPTION
### Description

Add [`react/jsx-newline`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-newline.md) rule with `prevent: false` option.

This rule enforces an empty line between adjacent JSX elements and expressions. Also this rule is automatically fixable using the `--fix` flag on the command line.