### PR TITLE
Add 'react/jsx-no-useless-fragment' rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ module.exports = {
     ],
     'react/jsx-no-duplicate-props': 'error',
     'react/jsx-no-undef': 'error',
+    'react/jsx-no-useless-fragment': 'error',
     'react/jsx-sort-default-props': 'error',
     'react/jsx-sort-props': 'error',
     'react/jsx-uses-react': 'error',


### PR DESCRIPTION
### Description

Add [`react/jsx-no-useless-fragment`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-newline.md) rule.

This rule disallows unnecessary fragments ie fragments that contains only one child, or if it is the child of a html element, and is not a keyed fragment. This rule is sometimes automatically fixable using the `--fix` flag on the command line.