### PR TITLE
Add 'react/jsx-sort-default-props' rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ module.exports = {
     'react/jsx-key': 'error',
     'react/jsx-no-duplicate-props': 'error',
     'react/jsx-no-undef': 'error',
+    'react/jsx-sort-default-props': 'error',
     'react/jsx-sort-props': 'error',
     'react/jsx-uses-react': 'error',
     'react/jsx-uses-vars': 'error',


### PR DESCRIPTION
### Description

Add [`react/jsx-sort-default-props`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-default-props.md) rule.

This rule enforces the alphabetically order on the default props, similar to `react/jsx-sort-props`.