### PR TITLE
Update 'react/boolean-prop-naming' rule to warn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ module.exports = {
     'jsx-quotes': ['error', 'prefer-double'],
     'new-cap': ['error', { capIsNewExceptions: ['BigNumber'] }],
     'react/boolean-prop-naming': [
-      'error',
+      'warn',
       {
         rule: '^(has|is|should)[A-Z]([A-Za-z0-9]?)+'
       }


### PR DESCRIPTION
Update 'react/boolean-prop-naming' rule to warn instead of error. This will allow a smoother transition.