### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.2.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/2.2.0) (2022-12-23)
+- Bump moment from 2.29.2 to 2.29.4 [\#41](https://github.com/uphold/eslint-config-uphold-react/pull/41) ([dependabot](https://github.com/apps/dependabot))
+- Bump minimatch from 3.0.4 to 3.1.2 [\#42](https://github.com/uphold/eslint-config-uphold-react/pull/42) ([dependabot](https://github.com/apps/dependabot))
+- Bump ansi-regex from 5.0.0 to 5.0.1 [\#43](https://github.com/uphold/eslint-config-uphold-react/pull/43) ([dependabot](https://github.com/apps/dependabot))
+- Update dependencies to the latest version [\#38](https://github.com/uphold/eslint-config-uphold-react/pull/38) ([NelsonBrandao](https://github.com/NelsonBrandao))
+- Update 'react/boolean-prop-naming' rule to warn [\#37](https://github.com/uphold/eslint-config-uphold-react/pull/37) ([NelsonBrandao](https://github.com/NelsonBrandao))
+- Bump ws from 5.2.2 to 5.2.3 [\#31](https://github.com/uphold/eslint-config-uphold-react/pull/31) ([dependabot](https://github.com/apps/dependabot))
+- Bump ajv from 6.10.2 to 6.12.6 [\#32](https://github.com/uphold/eslint-config-uphold-react/pull/32) ([dependabot](https://github.com/apps/dependabot))
+- Bump node-fetch from 2.6.1 to 2.6.7 [\#33](https://github.com/uphold/eslint-config-uphold-react/pull/33) ([dependabot](https://github.com/apps/dependabot))
+- Bump moment from 2.29.1 to 2.29.2 [\#36](https://github.com/uphold/eslint-config-uphold-react/pull/36) ([dependabot](https://github.com/apps/dependabot))
+- Update 'react-hooks/exhaustive-deps' rule to warn [\#35](https://github.com/uphold/eslint-config-uphold-react/pull/35) ([NelsonBrandao](https://github.com/NelsonBrandao))
+Done in 2.51s.
+
+
 ## [v2.1.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/v2.1.0) (2022-03-23)
 - Add 'react/boolean-prop-naming' rule [\#25](https://github.com/uphold/eslint-config-uphold-react/pull/25) ([NelsonBrandao](https://github.com/NelsonBrandao))
 - Add 'react-hooks/exhaustive-deps' rule [\#26](https://github.com/uphold/eslint-config-uphold-react/pull/26) ([NelsonBrandao](https://github.com/NelsonBrandao))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-uphold-react",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Uphold-flavored React ESLint config",
   "keywords": [
     "config",


### PR DESCRIPTION
## [Changelog](https://github.com/uphold/eslint-config-uphold-react/releases/tag/2.2.0) (2022-12-23)
- Bump moment from 2.29.2 to 2.29.4 [\#41](https://github.com/uphold/eslint-config-uphold-react/pull/41) ([dependabot](https://github.com/apps/dependabot))
- Bump minimatch from 3.0.4 to 3.1.2 [\#42](https://github.com/uphold/eslint-config-uphold-react/pull/42) ([dependabot](https://github.com/apps/dependabot))
- Bump ansi-regex from 5.0.0 to 5.0.1 [\#43](https://github.com/uphold/eslint-config-uphold-react/pull/43) ([dependabot](https://github.com/apps/dependabot))
- Update dependencies to the latest version [\#38](https://github.com/uphold/eslint-config-uphold-react/pull/38) ([NelsonBrandao](https://github.com/NelsonBrandao))
- Update 'react/boolean-prop-naming' rule to warn [\#37](https://github.com/uphold/eslint-config-uphold-react/pull/37) ([NelsonBrandao](https://github.com/NelsonBrandao))
- Bump ws from 5.2.2 to 5.2.3 [\#31](https://github.com/uphold/eslint-config-uphold-react/pull/31) ([dependabot](https://github.com/apps/dependabot))
- Bump ajv from 6.10.2 to 6.12.6 [\#32](https://github.com/uphold/eslint-config-uphold-react/pull/32) ([dependabot](https://github.com/apps/dependabot))
- Bump node-fetch from 2.6.1 to 2.6.7 [\#33](https://github.com/uphold/eslint-config-uphold-react/pull/33) ([dependabot](https://github.com/apps/dependabot))
- Bump moment from 2.29.1 to 2.29.2 [\#36](https://github.com/uphold/eslint-config-uphold-react/pull/36) ([dependabot](https://github.com/apps/dependabot))
- Update 'react-hooks/exhaustive-deps' rule to warn [\#35](https://github.com/uphold/eslint-config-uphold-react/pull/35) ([NelsonBrandao](https://github.com/NelsonBrandao))
Done in 2.51s.