### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
-## [2.4.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/2.4.0) (2023-01-06)
+## [v2.5.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/v2.5.0) (2024-06-12)
+- Bump dependencies [\#54](https://github.com/uphold/eslint-config-uphold-react/pull/54) ([heberbranco](https://github.com/heberbranco))
+- Release 2.4.0 [\#48](https://github.com/uphold/eslint-config-uphold-react/pull/48) ([NelsonBrandao](https://github.com/NelsonBrandao))
+
+## [v2.4.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/v2.4.0) (2023-01-06)
 - Add jsx new line rule [\#47](https://github.com/uphold/eslint-config-uphold-react/pull/47) ([diogoquintas](https://github.com/diogoquintas))
 
-## [2.3.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/2.3.0) (2023-01-03)
+## [v2.3.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/v2.3.0) (2023-01-03)
+- Release 2.3.0 [\#46](https://github.com/uphold/eslint-config-uphold-react/pull/46) ([NelsonBrandao](https://github.com/NelsonBrandao))
 - Update config rules [\#45](https://github.com/uphold/eslint-config-uphold-react/pull/45) ([diogoquintas](https://github.com/diogoquintas))
 
-## [2.2.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/2.2.0) (2022-12-23)
+## [v2.2.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/v2.2.0) (2022-12-23)
+- Release 2.2.0 [\#44](https://github.com/uphold/eslint-config-uphold-react/pull/44) ([NelsonBrandao](https://github.com/NelsonBrandao))
 - Bump moment from 2.29.2 to 2.29.4 [\#41](https://github.com/uphold/eslint-config-uphold-react/pull/41) ([dependabot](https://github.com/apps/dependabot))
 - Bump minimatch from 3.0.4 to 3.1.2 [\#42](https://github.com/uphold/eslint-config-uphold-react/pull/42) ([dependabot](https://github.com/apps/dependabot))
 - Bump ansi-regex from 5.0.0 to 5.0.1 [\#43](https://github.com/uphold/eslint-config-uphold-react/pull/43) ([dependabot](https://github.com/apps/dependabot))
@@ -18,8 +24,8 @@
 - Bump moment from 2.29.1 to 2.29.2 [\#36](https://github.com/uphold/eslint-config-uphold-react/pull/36) ([dependabot](https://github.com/apps/dependabot))
 - Update 'react-hooks/exhaustive-deps' rule to warn [\#35](https://github.com/uphold/eslint-config-uphold-react/pull/35) ([NelsonBrandao](https://github.com/NelsonBrandao))
 
-
 ## [v2.1.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/v2.1.0) (2022-03-23)
+- Release 2.1.0 [\#34](https://github.com/uphold/eslint-config-uphold-react/pull/34) ([NelsonBrandao](https://github.com/NelsonBrandao))
 - Add 'react/boolean-prop-naming' rule [\#25](https://github.com/uphold/eslint-config-uphold-react/pull/25) ([NelsonBrandao](https://github.com/NelsonBrandao))
 - Add 'react-hooks/exhaustive-deps' rule [\#26](https://github.com/uphold/eslint-config-uphold-react/pull/26) ([NelsonBrandao](https://github.com/NelsonBrandao))
 - Bump handlebars from 4.1.2 to 4.7.7 [\#15](https://github.com/uphold/eslint-config-uphold-react/pull/15) ([dependabot](https://github.com/apps/dependabot))
@@ -36,6 +42,7 @@
 - Add 'react/jsx-sort-default-props' rule [\#30](https://github.com/uphold/eslint-config-uphold-react/pull/30) ([NelsonBrandao](https://github.com/NelsonBrandao))
 
 ## [v2.0.0](https://github.com/uphold/eslint-config-uphold-react/releases/tag/v2.0.0) (2021-05-19)
+- Release 2.0.0 [\#19](https://github.com/uphold/eslint-config-uphold-react/pull/19) ([NelsonBrandao](https://github.com/NelsonBrandao))
 - Update major dependencies [\#18](https://github.com/uphold/eslint-config-uphold-react/pull/18) ([NelsonBrandao](https://github.com/NelsonBrandao))
 - Add new-cap rule `BigNumber` exception [\#7](https://github.com/uphold/eslint-config-uphold-react/pull/7) ([NelsonBrandao](https://github.com/NelsonBrandao))
 - Update package.json [\#6](https://github.com/uphold/eslint-config-uphold-react/pull/6) ([waldyrious](https://github.com/waldyrious))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-uphold-react",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Uphold-flavored React ESLint config",
   "keywords": [
     "config",


### PR DESCRIPTION
## [Changelog](https://github.com/uphold/eslint-config-uphold-react/releases/tag/v2.5.0) (2024-06-12)
- Bump dependencies [\#54](https://github.com/uphold/eslint-config-uphold-react/pull/54) ([heberbranco](https://github.com/heberbranco))